### PR TITLE
Change project order to match cards

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -37,13 +37,13 @@ const Layout = ({
 			</Head>
 			<NextSeo
 				title={`OpenClarity | ${pageTitle}`}
-				description="OpenClarity is a suite of open source tools for cloud native security and observability—APIClarity, KubeClarity and VMClarity."
+				description="OpenClarity is a suite of open source tools for cloud native security and observability — VMClarity, KubeClarity, and APIClarity."
 				canonical={`https://openclarity.io${pagePath || ""}`}
 				openGraph={{
 					url: `https://openclarity.io${pagePath || ""}`,
 					title: `OpenClarity | ${pageTitle}`,
 					description:
-						"OpenClarity is a suite of open source tools for cloud native security and observability—APIClarity, KubeClarity and VMClarity.",
+						"OpenClarity is a suite of open source tools for cloud native security and observability — VMClarity, KubeClarity, and APIClarity.",
 					images: [
 						{
 							url: "https://openclarity.io/assets/shared/logos/opengraph-logo.png",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -103,7 +103,7 @@ const HeroBanner = () => {
               <h1>What is OpenClarity?</h1>
               <h2>
                 OpenClarity is a suite of open source tools for cloud native
-                security and observability—APIClarity, KubeClarity and VMClarity.
+                security and observability — VMClarity, KubeClarity, and APIClarity.
               </h2>
               <h2>Read more about each project below.</h2>
             </div>


### PR DESCRIPTION
**Companion PR: https://github.com/openclarity/.github/pull/11**

Using these project cards from the index page as our reference, we should standardize our project ordering across both GitHub profile and OpenClarity website text to match:

<img width="1162" alt="Screen Shot 2023-04-20 at 4 41 02 PM" src="https://user-images.githubusercontent.com/2418071/233482945-71521c7f-3814-4199-b350-31c41bfb87d4.png">